### PR TITLE
Use Flux HelmRepository + HelmRelease for 
ingress-nginx

### DIFF
--- a/apps/ingress-nginx/helm-release.yaml
+++ b/apps/ingress-nginx/helm-release.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  chart:
+    spec:
+      chart: ingress-nginx
+      version: "4.7.1"
+      sourceRef:
+        kind: HelmRepository
+        name: ingress-nginx
+        namespace: flux-system
+  targetNamespace: ingress-nginx
+  values:
+    controller:
+      service:
+        type: LoadBalancer

--- a/apps/ingress-nginx/helm-repository.yaml
+++ b/apps/ingress-nginx/helm-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: flux-system
+spec:
+  url: https://kubernetes.github.io/ingress-nginx
+  interval: 10m0s

--- a/apps/ingress-nginx/kustomization.yaml
+++ b/apps/ingress-nginx/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.13.0/deploy/static/provider/cloud/deploy.yaml
+- namespace.yaml
+- helm-repository.yaml
+- helm-release.yaml

--- a/apps/ingress-nginx/namespace.yaml
+++ b/apps/ingress-nginx/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx


### PR DESCRIPTION
This PR switches the ingress-nginx overlay 
to deploy via Flux HelmRepository and HelmRelease instead
 of pulling static manifests.

    - Adds Namespace 'ingress-nginx'
    - Creates Flux HelmRepository pointing at
'https://kubernetes.github.io/ingress-nginx'
    - Defines Flux HelmRelease installing 'ingress-nginx'
 chart into the namespace
    