### PR TITLE
Deploy superfast-api to DigitalOcean cluster

### DIFF
--- a/apps/superfast-api/helm-release.yaml
+++ b/apps/superfast-api/helm-release.yaml
@@ -1,0 +1,36 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: superfast-api
+  namespace: superfast-api
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: ./apps/superfast-api
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  values:
+    replicaCount: 2
+    image:
+      repository: us-central1-docker.pkg.dev/sunlit-guild-373521/superfast/superfast
+      tag: "2025.05.24.01"
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 80
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    autoscaling:
+      enabled: false
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}

--- a/apps/superfast-api/ingress.yaml
+++ b/apps/superfast-api/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: superfast-api
+  namespace: superfast-api
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: superfast-api.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: superfast-api
+            port:
+              number: 80

--- a/apps/superfast-api/kustomization.yaml
+++ b/apps/superfast-api/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: superfast-api
+resources:
+  - namespace.yaml
+  - helm-release.yaml
+  - ingress.yaml

--- a/apps/superfast-api/namespace.yaml
+++ b/apps/superfast-api/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: superfast-api

--- a/clusters/digitalocean/kustomization.yaml
+++ b/clusters/digitalocean/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - ../../apps/simple-nginx
   - ../../apps/ingress-nginx
+  - ../../apps/superfast-api
   # Add more applications here as needed


### PR DESCRIPTION
## Summary
- Add superfast-api deployment using Helm release
- Configure namespace, HelmRelease, and ingress for the API
- Include superfast-api in DigitalOcean cluster kustomization

## Changes
- Created namespace.yaml for superfast-api namespace
- Added HelmRelease configuration to deploy from local chart
- Configured ingress for external access
- Updated cluster kustomization to include superfast-api

This will deploy the superfast API to the DigitalOcean Kubernetes cluster managed by FluxCD.